### PR TITLE
chore: add MVP build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: build
+on: [push, pull-request]
+
+jobs:
+  job:
+    name: ${{ matrix.os }}-${{ github.workflow }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+        - os: windows-latest
+          triplet: x64-windows
+        - os: ubuntu-latest
+          triplet: x64-linux
+        - os: macos-latest
+          triplet: x64-osx
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
+    - uses: lukka/get-cmake@latest
+
+    - name: Generate build system
+      run: |
+        cmake -S . -B build
+    # Build PureNES
+    - name: Build
+      run: |
+        cmake --build build
+    # Run tests
+    - name: Test
+      run: |
+        cd build && ctest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: build
-on: [push, pull-request]
+on: [push, pull_request]
 
 jobs:
   job:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
           triplet: x64-osx
 
     steps:
-
     - uses: actions/checkout@v2
 
     # Setup the build machine with the most recent versions of CMake and Ninja.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,18 +18,22 @@ jobs:
           triplet: x64-osx
 
     steps:
+
     - uses: actions/checkout@v2
 
-    # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
+    # Setup the build machine with the most recent versions of CMake and Ninja.
     - uses: lukka/get-cmake@latest
 
+    # Generate the build system
     - name: Generate build system
       run: |
         cmake -S . -B build
+
     # Build PureNES
     - name: Build
       run: |
         cmake --build build
+
     # Run tests
     - name: Test
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ enable_testing()
 
 # Configure test target
 add_executable(purenes_tests
-        test/cpu/cpu_test.cpu)
+        test/cpu/cpu_test.cpp)
 
 target_include_directories(purenes_tests PRIVATE include/purenes)
 target_link_libraries(purenes_tests gtest_main)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# purenes
+# Purenes
+
+[![build](https://github.com/zeeps31/purenes/actions/workflows/build.yml/badge.svg)](https://github.com/zeeps31/purenes/actions/workflows/build.yml)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Purenes
+# PureNES
 
 [![build](https://github.com/zeeps31/purenes/actions/workflows/build.yml/badge.svg)](https://github.com/zeeps31/purenes/actions/workflows/build.yml)


### PR DESCRIPTION
### Notes

This change adds an MVP Github workflow to build PureNES on ubuntu-latest, macos-latest and windows-latest and run tests. The README is updated with a workflow status badge. 

### Testing 
* cmake -S . -B build
* cmake --build build
* cd build && ctest