### PR TITLE
feat: add CPUBus

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
     # Run tests
     - name: Test
       run: |
-        cd build && ctest
+        ctest --test-dir build/test

--- a/include/bus.h
+++ b/include/bus.h
@@ -1,0 +1,29 @@
+#ifndef NESTALGIC_BUS_H_
+#define NESTALGIC_BUS_H_
+
+#include <cstdint>
+
+namespace nestalgic {
+// Interface to represent a "Bus" on the NES.
+//
+// Both the CPU and PPU have busses that are connected to various components on the
+// NES.
+class Bus {
+ public:
+  Bus() = default;
+  // Ensure proper cleanup in derived classes
+  virtual ~Bus() = default;
+
+  // There should not be any scenarios where a Bus will be copied
+  Bus(const Bus& bus) = delete;
+  auto operator=(const Bus&) -> Bus& = delete;
+
+  // Prevent moving. Bus should only be initialized once and does not need to be be transferred
+  Bus(Bus&&) = delete;
+  auto operator=(const Bus&&) -> Bus& = delete;
+
+  virtual auto Read(uint16_t address) -> uint8_t = 0;
+  virtual void Write(uint16_t address, uint8_t data) = 0;
+};
+}  // namespace nestalgic
+#endif  // NESTALGIC_BUS_H_

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -1,4 +1,57 @@
-#ifndef PURENES_CPU_H
-#define PURENES_CPU_H
+#ifndef NESTALGIC_CPU_H_
+#define NESTALGIC_CPU_H_
 
-#endif //PURENES_CPU_H
+#include <array>
+#include <cstdint>
+
+#include "bus.h"
+
+const int CPU_RAM_SIZE{0x0800};  // 2048 (2KB of ram)
+
+namespace nestalgic {
+
+// Represents the NES CPU bus, handling memory reads and writes.
+//
+// The CPU bus determines which memory-mapped resource (RAM, PPU, APU, or cartridge ROM)
+// should handle a given address based on the NES memory map.
+//
+// NES Memory Map: https://www.nesdev.org/wiki/CPU_memory_map
+//
+// ┌──────────────────┬────────┬──────────────────────────────────────────────┐
+// │ Address Range    │  Size  │ Description                                  │
+// ├──────────────────┼────────┼──────────────────────────────────────────────┤
+// │ $0000 - $07FF    │ 2 KB   │ Internal RAM                                 │
+// │ $0800 - $1FFF    │ Mirror │ Repeats every $0800 bytes                    │
+// │ $2000 - $2007    │ 8 B    │ PPU Registers                                │
+// │ $2008 - $3FFF    │ Mirror │ PPU Regs (Mirrored every 8 bytes)            │
+// │ $4000 - $4017    │ 24 B   │ APU and I/O Registers                        │
+// │ $4018 - $401F    │ 8 B    │ APU and I/O (typically unused)               │
+// │ $4020 - $FFFF    │ 48 KB  │ Cartridge ROM, PRG RAM, and Mapper Registers │
+// └──────────────────┴────────┴──────────────────────────────────────────────┘
+class CPUBus : public Bus {
+ public:
+  // Reads a byte from memory at the given address.
+  //
+  // Args:
+  //   address: The 16-bit memory address to read from.
+  //
+  // Returns:
+  //   The byte value stored at the given memory address.
+  auto Read(uint16_t address) -> uint8_t override;
+
+  // Writes a byte to memory at the given address.
+  //
+  // Args:
+  //   address: The 16-bit memory address to write to.
+  //   data: The 8-bit data to write to the memory address.
+  //
+  // Returns:
+  //   The byte value stored at the given memory address.
+  auto Write(uint16_t address, uint8_t data) -> void override;
+
+ private:
+  // 2KB of internal RAM on the CPU bus
+  std::array<uint8_t, CPU_RAM_SIZE> ram_{};
+};
+}  // namespace nestalgic
+#endif  // NESTALGIC_CPU_H_

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1,0 +1,39 @@
+#include "cpu.h"
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+
+// Used to implement mirroring in CPU ram. CPU ram addresses are mirrored every 2048 bytes (0x0800)
+const uint16_t CPU_RAM_ADDRESS_MASK{0x07FF};
+// The max address for the CPU RAM addressable range
+const uint16_t CPU_RAM_MAX_RANGE{0x1FFF};
+
+const char NEWLINE{'\n'};
+const int BITS_PER_BYTE{8};
+
+namespace nestalgic {
+
+auto CPUBus::Read(uint16_t address) -> uint8_t {
+  // RAM region: $0000 - $1FFF (mirrored every $0800), address & 0x07FF isolates only the lower 11 bits
+  if (address >= 0x0000 && address <= CPU_RAM_MAX_RANGE) {
+    return ram_.at(address & CPU_RAM_ADDRESS_MASK);
+  }
+
+  // Log error message and return a safe default value
+  std::cerr << "Error: Invalid address provided Address should be between 0x0000 - 0xFFFF."
+            << NEWLINE;
+  return 0;
+}
+
+auto CPUBus::Write(uint16_t address, uint8_t data) -> void {
+  // RAM region: $0000 - $1FFF (mirrored every $0800), address & 0x07FF isolates only the lower 11 bits
+  if (address >= 0x0000 && address <= CPU_RAM_MAX_RANGE) {
+    ram_.at(address & CPU_RAM_ADDRESS_MASK) = data;
+  }
+
+  // Log error message and return a safe default value
+  std::cerr << "Error: Invalid address provided Address should be between 0x0000 - 0xFFFF."
+            << NEWLINE;
+}
+}  // namespace nestalgic

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ FetchContent_MakeAvailable(googletest)
 # Configure test target
 add_executable(nestalgic_tests
         cpu_test.cpp
+        cpu_bus_test.cpp
 )
 
 target_include_directories(nestalgic_tests PRIVATE ${CMAKE_SOURCE_DIR}/include)

--- a/test/cpu_bus_test.cpp
+++ b/test/cpu_bus_test.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <tuple>
+
+#include "cpu.h"
+
+// A test suite for verifying CPUBus memory read/write behavior.
+//
+// This parameterized test ensures that writing data to a specific memory address
+// and reading it from another address produces the expected result. This is
+// particularly useful for testing memory mirroring, where certain addresses map
+// to the same underlying memory region.
+namespace {
+class CPUBusTest : public ::testing::TestWithParam<std::tuple<uint16_t, uint16_t, uint8_t>> {
+ protected:
+  nestalgic::CPUBus testObject;  // Object under test
+};
+
+// Tests CPUBus RAM access by writing a byte to a memory address and
+// reading it from a potentially mirrored address.
+//
+// This test is designed to verify both standard memory reads and
+// memory mirroring behavior when implemented.
+//
+// Args:
+//   writeAddress: The memory address where data is written.
+//   readAddress: The memory address from which data is read.
+//   data: The byte value to write and expect when reading.
+TEST_P(CPUBusTest, TestRamAccess) {
+  // Arrange
+  const uint16_t writeAddress = std::get<0>(GetParam());
+  const uint16_t readAddress = std::get<1>(GetParam());
+  const uint8_t data = std::get<2>(GetParam());
+
+  // Act
+  testObject.Write(writeAddress, data);
+
+  // Assert
+  EXPECT_EQ(testObject.Read(readAddress), data);
+}
+
+// Instantiates test cases for CPUBus memory access.
+//
+// This set of test cases ensures that writing to one memory location and
+// reading from another (potentially mirrored) location behaves correctly.
+//
+// Test Cases:
+//   (0x0000, 0x0000, 0x01) - Writing to address 0x0000 and reading from 0x0000.
+//   (0x0000, 0x0800, 0x01) - Writing to address 0x00800 and reading from 0x0000. The address should
+//   be mirrored back to 0x0000.
+//   (0x1FFF, 0x07FF, 0x01) - Writing to address 0x1FFF (the maximum of RAM addressable range)
+//   should mirror back to 0x07FF (the maximum capacity of the RAM)
+INSTANTIATE_TEST_SUITE_P(CPURamAccessTestCases, CPUBusTest,
+                         ::testing::Values(std::make_tuple(0x0000, 0x0000, 0x01),
+                                           std::make_tuple(0x0800, 0x0000, 0x01),
+                                           std::make_tuple(0x1FFF, 0x07FF, 0x01)));
+
+}  // namespace


### PR DESCRIPTION
### Notes

This change adds support a CPUBus class. The class is implemented with a Read and Write operation. Support is added for reads and writes to CPU RAM.

1. Add Bus interface. Since the CPU and PPU both have a Bus an interface is provided. Moreover, defining an interface with virtual methods allows mocking in GTest for CPU methods.
2. Add CPUBus to cpu.h and cpu.cpp. The CPUBus is implemented with support for reads and writes to RAM.
3. A suite of tests is added to cpu_bus_tests to verify behavior.
4. The .github/workflows/build.yml is updated to invoke the correct test command.

### Testing
* `cmake --build build`
* `clang-tidy -p build include/*.h src/*.cpp test/*.cpp`
* `ctest --test-dir build/test`

```
Internal ctest changing into directory: /Users/stephenbrady/workplace/nestalgic/build/test
Test project /Users/stephenbrady/workplace/nestalgic/build/test
    Start 1: CPURamAccessTestCases/CPUBusTest.TestRamAccess/(0, 0, '\x1' (1))
1/3 Test #1: CPURamAccessTestCases/CPUBusTest.TestRamAccess/(0, 0, '\x1' (1)) .........   Passed    0.01 sec
    Start 2: CPURamAccessTestCases/CPUBusTest.TestRamAccess/(2048, 0, '\x1' (1))
2/3 Test #2: CPURamAccessTestCases/CPUBusTest.TestRamAccess/(2048, 0, '\x1' (1)) ......   Passed    0.00 sec
    Start 3: CPURamAccessTestCases/CPUBusTest.TestRamAccess/(8191, 2047, '\x1' (1))
3/3 Test #3: CPURamAccessTestCases/CPUBusTest.TestRamAccess/(8191, 2047, '\x1' (1)) ...   Passed    0.00 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   0.02 sec
```