### PR TITLE
feat: add CPU implementation

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -2,13 +2,30 @@
 #define NESTALGIC_CPU_H_
 
 #include <array>
+#include <bitset>
 #include <cstdint>
+#include <unordered_map>
 
 #include "bus.h"
 
 const int CPU_RAM_SIZE{0x0800};  // 2048 (2KB of ram)
 
 namespace nestalgic {
+
+// Forward declare the class before using it in CPU
+namespace internal {
+class CPUTestHelper;
+}
+
+enum class AddressingMode : std::uint8_t { Immediate };
+enum CPUStatusFlag : std::uint8_t {
+  Negative = 7,
+  Overflow = 6,
+  Decimal = 3,
+  InterruptDisable = 2,
+  Zero = 1,
+  Carry = 0
+};
 
 // Represents the NES CPU bus, handling memory reads and writes.
 //
@@ -53,5 +70,141 @@ class CPUBus : public Bus {
   // 2KB of internal RAM on the CPU bus
   std::array<uint8_t, CPU_RAM_SIZE> ram_{};
 };
+
+// A high-level, non-cycle-accurate implementation of the MOS 6502 processor.
+//
+// This class emulates the 8-bit Ricoh 2A03 CPU (based on the MOS 6502) used in the NES.
+// It handles instruction decoding, memory access, and register management, but does
+// not implement cycle-accurate behavior.
+//
+// This implementation follows the general behavior of the NES CPU, but timing-sensitive
+// operations (such as cycle-exact sprite evaluation and interrupts) may not be accurate.
+//
+// More details: https://www.nesdev.org/wiki/CPU
+class CPU {
+ public:
+  // Constructs a CPU instance and connects it to the given bus.
+  //
+  // Args:
+  //   cpuBus: Pointer to the system bus, used for memory reads/writes.
+  explicit CPU(Bus* cpuBus);
+
+  // Executes a single CPU cycle.
+  //
+  // The CPU fetches, decodes, and executes one instruction step per call.
+  void Clock();
+
+  // Resets the CPU to its initial state.
+  //
+  // This resets all registers, clears internal state, and sets the program counter
+  // to the address stored in the reset vector ($FFFC-$FFFD).
+  void Reset();
+
+ private:
+  class CPUStatus {
+    // NOLINTBEGIN(*-magic-numbers) 8 is used as this will represent a single byte (8 bits)
+    std::bitset<8> flags;
+    // NOLINTEND(*-magic-numbers)
+
+   public:
+    void Set(CPUStatusFlag flag, bool value) { flags.set(flag, value); }
+
+    auto Get(CPUStatusFlag flag) -> bool { return flags.test(flag); }
+
+    void FromByte(uint8_t value) {
+      // NOLINTBEGIN(*-magic-numbers) 8 is used as this will represent a single byte (8 bits)
+      flags = std::bitset<8>(value);
+      // NOLINTEND(*-magic-numbers)
+    }
+
+    auto ToByte() -> uint8_t { return static_cast<uint8_t>(flags.to_ulong()); }
+  };
+
+  // Internal registers and bus
+  Bus* cpu_bus_;
+
+  uint8_t a_{0x00};
+  uint8_t x_{0x00};
+  uint8_t y_{0x00};
+  uint16_t pc_{0x0000};
+  uint8_t s_{0xFF}; // NOLINT(*-magic-numbers)
+  CPUStatus p_;
+
+ private:
+  // Internal helper functions and class members
+  friend class internal::CPUTestHelper;
+
+  uint8_t opcode_ = 0x00;
+  uint8_t operand_ = 0x00;  // The value retrieved using the addressing mode.
+  int remaining_cycles_ = 0;
+
+  auto Read(uint16_t address) -> uint8_t;
+  auto FetchOperand(AddressingMode addressingMode) -> uint8_t;
+
+ private:
+  // Opcode declarations
+  struct OpcodeEntry {
+    AddressingMode addressingMode;
+    void (CPU::*operation)();  // Points to a member function of the class (opcode)
+    int cycleCount;
+  };
+
+  std::unordered_map<uint8_t, OpcodeEntry> operations_;
+  void LoadOperations();
+  void LDA();
+};
+
+namespace internal {
+// A helper class for unit testing the CPU.
+//
+// This class provides direct access to the CPU's internal registers for testing purposes.
+// It allows test cases to manipulate and verify the CPU state without executing instructions.
+//
+// This class should only be used in test environments and is not part of the public API.
+class CPUTestHelper {
+ public:
+  // Sets the CPU's accumulator register.
+  //
+  // Args:
+  //   cpu: Reference to the CPU instance.
+  //   accumulatorValue: The value to set in the accumulator (A register).
+  static void SetAccumulator(CPU& cpu, uint8_t accumulatorValue);
+
+  // Retrieves the value of the CPU's accumulator register.
+  //
+  // Args:
+  //   cpu: Reference to the CPU instance.
+  //
+  // Returns:
+  //   The current value of the accumulator.
+  static auto GetAccumulator(CPU& cpu) -> uint8_t;
+
+  // Sets the CPU's program counter (PC).
+  //
+  // Args:
+  //   cpu: Reference to the CPU instance.
+  //   programCounter: The new program counter value.
+  static void SetProgramCounter(CPU& cpu, uint16_t programCounter);
+
+  // Retrieves the CPU's current program counter value.
+  //
+  // Args:
+  //   cpu: Reference to the CPU instance.
+  //
+  // Returns:
+  //   The current program counter value.
+  static auto GetProgramCounter(CPU& cpu) -> uint16_t;
+
+  // Retrieves a status flag from the CPU
+  //
+  // Args:
+  //   cpu: Reference to the CPU instance.
+  //   flag: The CPUStatusFlag to retrieve
+  //
+  // Returns:
+  //   The value at the status flag
+  static auto GetStatusFlag(CPU& cpu, CPUStatusFlag flag) -> bool;
+};
+};  // namespace internal
 }  // namespace nestalgic
 #endif  // NESTALGIC_CPU_H_

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -4,10 +4,18 @@
 #include <cstdint>
 #include <iostream>
 
+#include "bus.h"
+
+// The low byte of where the reset vector address. This value and the value stored at 0xFFFD are
+// combined to form a single address that is used to set the program counter upon reset
+const uint16_t RESET_VECTOR_LOW_BYTE{0xFFFC};
+
 // Used to implement mirroring in CPU ram. CPU ram addresses are mirrored every 2048 bytes (0x0800)
 const uint16_t CPU_RAM_ADDRESS_MASK{0x07FF};
 // The max address for the CPU RAM addressable range
 const uint16_t CPU_RAM_MAX_RANGE{0x1FFF};
+
+const uint8_t STACK_POINTER_DEFAULT{0xFF};
 
 const char NEWLINE{'\n'};
 const int BITS_PER_BYTE{8};
@@ -36,4 +44,101 @@ auto CPUBus::Write(uint16_t address, uint8_t data) -> void {
   std::cerr << "Error: Invalid address provided Address should be between 0x0000 - 0xFFFF."
             << NEWLINE;
 }
+
+// Connects the CPUBus to the CPU and loads operations into an opcode mapping.
+CPU::CPU(Bus* cpuBus) : cpu_bus_(cpuBus) {
+  assert(cpu_bus_ != nullptr);
+  LoadOperations();
+}
+
+// Each time the CPU is clocked and the remaining cycle counter is 0, the
+// following events occur:
+//
+// 1. The CPU reads from CPUBus at the address stored in the program counter.
+// 2. The program counter is incremented by one.
+// 3. The operation retrieved from the address at the program counter is executed.
+//
+// If there are still remaining cycles for the operation, the remaining
+// cycle counter is decremented and no action is performed.
+void CPU::Clock() {
+  if (remaining_cycles_ == 0) {
+    opcode_ = Read(pc_++);
+    const OpcodeEntry opcodeEntry = operations_[opcode_];
+
+    operand_ = FetchOperand(opcodeEntry.addressingMode);
+    (this->*opcodeEntry.operation)();
+    remaining_cycles_ += opcodeEntry.cycleCount;
+  }
+
+  remaining_cycles_--;
+}
+
+void CPU::Reset() {
+  // Reset registers to their initial state
+  a_ = 0x00;
+  x_ = 0x00;
+  y_ = 0x00;
+  s_ = STACK_POINTER_DEFAULT;
+  p_.FromByte(0x00);
+
+  // Fetch the reset vector ($FFFC-$FFFD), which contains the program's entry point
+  const uint8_t pc_lo{Read(RESET_VECTOR_LOW_BYTE)};
+  const uint8_t pc_hi{Read(RESET_VECTOR_LOW_BYTE + 1)};
+
+  // Combine the low and high bytes to form the 16-bit program counter (little-endian format)
+  pc_ = pc_hi << BITS_PER_BYTE | pc_lo;
+
+  // As the reset line goes high the processor performs a start sequence of 7 cycles
+  const int reset_cycle_count = 7;
+  remaining_cycles_ += reset_cycle_count;
+}
+
+// Read a value from the CPU bus. This method is a wrapper around the CPU bus. All reads will simply
+// be delegated to the CPUBus.
+auto CPU::Read(uint16_t address) -> uint8_t { return cpu_bus_->Read(address); }
+
+// Fetches the operand for the current operation based on the addressing mode
+//
+// Uses the AddressingMode enum to determine how the operand should be fetched, executes the
+// addressing mode and returns the value.
+auto CPU::FetchOperand(AddressingMode addressingMode) -> uint8_t {
+  switch (addressingMode) {
+    case AddressingMode::Immediate:
+      return Read(pc_++);
+  }
+
+  // Log an error message and return a safe default value
+  std::cerr << "Error: Unsupported addressing mode in FetchOperand()" << NEWLINE;
+  return 0;  // Default return value
+}
+
+// Load Accumulator with Memory (LDA)
+void CPU::LDA() {
+  a_ = operand_;
+
+  p_.Set(CPUStatusFlag::Negative, (a_ & 0x80) != 0x00); // NOLINT(*-magic-numbers)
+  p_.Set(CPUStatusFlag::Zero, a_ == 0x00);
+}
+
+void CPU::LoadOperations() {
+  // NOLINTBEGIN(*-magic-numbers)
+  operations_ = {{0xA9, {AddressingMode::Immediate, &CPU::LDA, 2}}};
+  // NOLINTEND(*-magic-numbers)
+}
+
+namespace internal {
+void CPUTestHelper::SetAccumulator(CPU& cpu, uint8_t accumulatorValue) {
+  cpu.a_ = accumulatorValue;
+}
+
+auto CPUTestHelper::GetAccumulator(CPU& cpu) -> uint8_t { return cpu.a_; }
+
+void CPUTestHelper::SetProgramCounter(CPU& cpu, uint16_t programCounter) {
+  cpu.pc_ = programCounter;
+}
+
+auto CPUTestHelper::GetProgramCounter(CPU& cpu) -> uint16_t { return cpu.pc_; }
+
+auto CPUTestHelper::GetStatusFlag(CPU& cpu, CPUStatusFlag flag) -> bool { return cpu.p_.Get(flag); }
+}  // namespace internal
 }  // namespace nestalgic

--- a/test/cpu_test.cpp
+++ b/test/cpu_test.cpp
@@ -1,0 +1,76 @@
+#include <cstdint>
+#include <tuple>
+#include <gmock/gmock.h>
+#include "gtest/gtest.h"
+
+#include "bus.h"
+#include "cpu.h"
+
+using ::testing::Return;
+using nestalgic::internal::CPUTestHelper;
+
+namespace {
+
+class MockCPUBus : public nestalgic::Bus {
+ public:
+  // Trailing return types are not supported in MOCK_METHOD
+  MOCK_METHOD(uint8_t, Read, (uint16_t address), (override)); // NOLINT (*-use-trailing-return-type)
+  MOCK_METHOD(void, Write, (uint16_t address, uint8_t data), (override));
+};
+
+// Parameterized test for CPU transfer operations.
+//
+// This test verifies the behavior of CPU register transfers using different
+// combinations of input values. Each test case is defined as a tuple.
+//
+// Args:
+//   - uint8_t: Initial value read at the program counter. This is the opcode.
+//   - uint8_t: The value of the operand when the read from the address at the PC.
+//   - int: Expected cycle count for the operation.
+//   - bool: Whether the Negative flag (N) should be set after execution.
+//   - bool: Whether the Zero flag (Z) should be set after execution.
+class CPUTransferOperationsTest
+    : public ::testing::TestWithParam<std::tuple<uint8_t, uint8_t, int, bool, bool>> {
+ protected:
+  MockCPUBus mockCPUBus;
+  nestalgic::CPU testObject{&mockCPUBus};  // Object under test
+};
+
+// Tests the LDA (Load Accumulator) operation using Immediate Addressing Mode.
+//
+// This parameterized test verifies that the CPU correctly loads a value into the accumulator
+// from an immediate operand, sets the appropriate status flags, and consumes the correct
+// number of cycles.
+TEST_P(CPUTransferOperationsTest, TestLDAOperationImmediateAddressing) {
+  // Set the CPU program counter to the start of execution.
+  CPUTestHelper::SetProgramCounter(testObject, 0x0000);
+
+  // Expect the CPU to fetch the opcode (LDA immediate).
+  EXPECT_CALL(mockCPUBus, Read(0x0000)).WillOnce(Return(std::get<0>(GetParam())));  // Return opcode
+
+  // Expect the CPU to fetch the operand (immediate value).
+  EXPECT_CALL(mockCPUBus, Read(0x0001))
+      .WillOnce(Return(std::get<1>(GetParam())));  // Return operand
+
+  // Clock the CPU for the number of cycles required by the operation.
+  for (int i = 0; i < std::get<2>(GetParam()); i++) {
+    testObject.Clock();
+  }
+
+  // Clock the CPU for the number of cycles required by the operation.
+  EXPECT_EQ(CPUTestHelper::GetAccumulator(testObject), std::get<1>(GetParam()));
+
+  // Verify that the Negative flag (N) is set correctly.
+  EXPECT_EQ(CPUTestHelper::GetStatusFlag(testObject, nestalgic::CPUStatusFlag::Negative),
+            std::get<3>(GetParam()));
+
+  // Verify that the Zero flag (Z) is set correctly.
+  EXPECT_EQ(CPUTestHelper::GetStatusFlag(testObject, nestalgic::CPUStatusFlag::Zero),
+            std::get<4>(GetParam()));
+}
+
+INSTANTIATE_TEST_SUITE_P(TestLDAOperationValues, CPUTransferOperationsTest,
+                         ::testing::Values(std::make_tuple(0xA9, 0x01, 2, 0, 0),
+                                           std::make_tuple(0xA9, 0x00, 2, 0, 1),
+                                           std::make_tuple(0xA9, 0x80, 2, 1, 0)));
+}  // namespace


### PR DESCRIPTION
### Notes

This change adds a baseline implementation of the NES CPU. It publicly declares a `Clock` and `Reset` method and adds support for internal registers and status flags. In addition, an internal `CPUTestHelper` class is added to an `internal` namespace to help with testing.

As a baseline implementation, support for the `LDA` operation with `Immediate` addressing is added.

### Testing
* `cmake --build build `
* `clang-tidy -p build include/*.h src/*.cpp test/*.cpp`
* `ctest --build-dir build/test` 

```
Internal ctest changing into directory: /Users/stephenbrady/workplace/nestalgic/build/test
Test project /Users/stephenbrady/workplace/nestalgic/build/test
    Start 1: TestLDAOperationValues/CPUTransferOperationsTest.TestLDAOperationImmediateAddressing/('\xA9' (169), '\x1' (1), 2, false, false)
1/6 Test #1: TestLDAOperationValues/CPUTransferOperationsTest.TestLDAOperationImmediateAddressing/('\xA9' (169), '\x1' (1), 2, false, false) .....   Passed    0.01 sec
    Start 2: TestLDAOperationValues/CPUTransferOperationsTest.TestLDAOperationImmediateAddressing/('\xA9' (169), '\0', 2, false, true)
2/6 Test #2: TestLDAOperationValues/CPUTransferOperationsTest.TestLDAOperationImmediateAddressing/('\xA9' (169), '\0', 2, false, true) ...........   Passed    0.01 sec
    Start 3: TestLDAOperationValues/CPUTransferOperationsTest.TestLDAOperationImmediateAddressing/('\xA9' (169), '\x80' (128), 2, true, false)
3/6 Test #3: TestLDAOperationValues/CPUTransferOperationsTest.TestLDAOperationImmediateAddressing/('\xA9' (169), '\x80' (128), 2, true, false) ...   Passed    0.01 sec
    Start 4: CPURamAccessTestCases/CPUBusTest.TestRamAccess/(0, 0, '\x1' (1))
4/6 Test #4: CPURamAccessTestCases/CPUBusTest.TestRamAccess/(0, 0, '\x1' (1)) ....................................................................   Passed    0.00 sec
    Start 5: CPURamAccessTestCases/CPUBusTest.TestRamAccess/(2048, 0, '\x1' (1))
5/6 Test #5: CPURamAccessTestCases/CPUBusTest.TestRamAccess/(2048, 0, '\x1' (1)) .................................................................   Passed    0.00 sec
    Start 6: CPURamAccessTestCases/CPUBusTest.TestRamAccess/(8191, 2047, '\x1' (1))
6/6 Test #6: CPURamAccessTestCases/CPUBusTest.TestRamAccess/(8191, 2047, '\x1' (1)) ..............................................................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 6
```